### PR TITLE
Bumping upstream to 0.38

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,11 @@ FROM arm32v7/golang as builder
 
 MAINTAINER Ondřej Záruba <info@zaruba-ondrej.cz> (https://zaruba-ondrej.cz)
 
-ENV CADVISOR_VERSION "v0.30.2"
+ENV CADVISOR_VERSION "v0.38"
 
 RUN apt-get update && apt-get install -y git dmsetup && apt-get clean
 
-RUN git clone --branch ${CADVISOR_VERSION} https://github.com/google/cadvisor.git /go/src/github.com/google/cadvisor
+RUN git clone --branch release-${CADVISOR_VERSION} https://github.com/google/cadvisor.git /go/src/github.com/google/cadvisor
 
 WORKDIR /go/src/github.com/google/cadvisor
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This package compile official [google/cadvisor](https://github.com/google/cadvis
 
 **NOTE:** Tag corresponds to the version of cAdvisor
 
-* `0.30.2`, `latest` - [(Dockerfile)](https://github.com/Budry/cadvisor-arm/blob/v0.30.2/Dockerfile)
+* `0.30.2` - [(Dockerfile)](https://github.com/Budry/cadvisor-arm/blob/v0.30.2/Dockerfile)
 * `0.29.0` - [(Dockerfile)](https://github.com/Budry/cadvisor-arm/blob/v0.29.0/Dockerfile)
 * `0.28.3` - [(Dockerfile)](https://github.com/Budry/cadvisor-arm/blob/v0.28.3/Dockerfile)
 


### PR DESCRIPTION
Bumping cadvisor to 0.38. Tried newer versions as well but on Pi 4B this was so far the only version that was both compiling and working. I also changed the way Dockerfile refers to the branch instead of tags, feel free to change that back if you don't agree.

Some error messages I was able to fix by adjusting the command line e.g.:

    command:
      - '--raw_cgroup_prefix_whitelist=/docker/'
      - '--disable_metrics=hugetlb

Still complaining about smaps (Cannot read smaps files for any PID from CONTAINER), that might require further investigation.